### PR TITLE
Install flow & watchman by default for ReactNative

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -146,6 +146,8 @@
     - homebrew: name=node state=present
     - homebrew: name=ansible state=present
     - homebrew: name=coreutils state=present
+    - homebrew: name=watchman state=present
+    - homebrew: name=flow state=present
 
     # Ruby
     # - homebrew: name=ruby state=present


### PR DESCRIPTION
As ReactNative has been gaining a massive amount of popularity, I think it would be a good idea to include their needed tools `watchman` and `flow` for increased build speed