### PR TITLE
use full, non one liner if syntax, or else source can fail

### DIFF
--- a/profiles/bashrc
+++ b/profiles/bashrc
@@ -14,9 +14,13 @@ export GOPATH="$HOME/go"
 export PATH="$PATH:$GOPATH/bin"
 
 # Bitrise environments
-[[ -s "$HOME/.profiles/bitrise_profile" ]] && source "$HOME/.profiles/bitrise_profile"
+if [ -s "$HOME/.profiles/bitrise_profile" ] ; then
+  source "$HOME/.profiles/bitrise_profile"
+fi
 
 # Xamarin environments, if exists
-[[ -s "$HOME/.profiles/xamarin_profile" ]] && source "$HOME/.profiles/xamarin_profile"
+if [ -s "$HOME/.profiles/xamarin_profile" ] ; then
+  source "$HOME/.profiles/xamarin_profile"
+fi
 
 # keep a newline at the end of this file


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added

if `set -e` is enabled the one liner fails!