### PR TITLE
Update weekly-cache-update-playbook.yml

### DIFF
--- a/weekly-cache-update-playbook.yml
+++ b/weekly-cache-update-playbook.yml
@@ -47,6 +47,9 @@
     - name: "CocoaPods: checkout spec repo - for deprecated cocoapods versions"
       shell: bash -l -c "cd /Users/vagrant/.cocoapods/repos/master/ && git fetch origin master --tags && git checkout v0.32.1"
       when: use_deprecated_cocoapods|default("") == "yes"
+    - name: "CocoaPods: pre-fetch the Old-Specs spec, to update it to the latest version"
+      shell: bash -l -c "pod repo add cocoapods https://github.com/CocoaPods/Old-Specs"
+      when: use_deprecated_cocoapods|default("") == "yes"
 
 
     # ----------------------------------------


### PR DESCRIPTION
To speed up builds on older stacks, where CocoaPods 0.x is used - when you use `https://github.com/CocoaPods/Old-Specs` as the spec source in your `Podfile`, as suggested at http://blog.cocoapods.org/Sharding/

> For people who want to continue using 0.x versions, we will be replicating the Specs repo from the commit before the repo was sharded. This means you can add: `source "https://github.com/CocoaPods/Old-Specs"`