### PR TITLE
OpenSSL libraries for .net core support

### DIFF
--- a/xamarin-playbook.yml
+++ b/xamarin-playbook.yml
@@ -148,6 +148,11 @@
     # --- Install .NET Core
 
     # Download install script
+    - name: Setup pre-requisites
+      shell: brew install openssl
+    - shell: mkdir -p /usr/local/lib
+    - shell: ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
+    - shell: ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
     - name: Download .net core install script
       shell: wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.1/scripts/obtain/dotnet-install.sh
     - name: Run the install script


### PR DESCRIPTION
In order to use .NET Core, you first need to install the latest version of OpenSSL.

It seemed that this was working without it before, but possible there was some caching going on on some VM's. 

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
