### PR TITLE
v2017_05_02_1 - remove preinstalled dotNet Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 ## UPCOMING
 
 
+## `v2017_05_02_1`
+
+* Xamarin Only: .Net Core __removed__, no longer preinstalled. Please use the new `install-dotnetcore` step instead.
+    * Thanks @stefandevo for the changes!
+    * TL;DR; installation of .Net Core right now is still a bit "beta", we'll consider pre-installing .Net Core
+      in the future again once it lands in `brew`. Until that it's way more flexible to use a Step
+      instead, which can be updated any time, instead of sticking to a preinstalled version
+      which is hard & slow to change.
+    * Related discussion: https://github.com/bitrise-io/osx-box-bootstrap/pull/44
+
+
 ## `v2017_04_25_1`
 
 * Xamarin Only: .Net Core preinstalled

--- a/profiles/bitrise_profile
+++ b/profiles/bitrise_profile
@@ -1,6 +1,6 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
-export BITRISE_OSX_STACK_REV_ID=v2017_04_25_1
+export BITRISE_OSX_STACK_REV_ID=v2017_05_02_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/system_report.sh
+++ b/system_report.sh
@@ -173,8 +173,6 @@ if [ ! -z "$BITRISE_XAMARIN_FOLDER_PATH" ] ; then
   mono --version
   echo "* Mono path:"
   which mono
-  echo "* .NET Core version:"
-  dotnet --version  
   echo
   echo "* Xamarin.Android"
   cat /Developer/MonoAndroid/usr/Version

--- a/xamarin-playbook.yml
+++ b/xamarin-playbook.yml
@@ -144,19 +144,6 @@
         owner="{{ param_user }}"
         mode=0644
 
-    # ------------------------------------------------------
-    # --- Install .NET Core
-
-    # Download install script
-    - name: Download .net core install script
-      shell: wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.1/scripts/obtain/dotnet-install.sh
-    - name: Run the install script
-      shell: bash dotnet-install.sh
-    - name: Delete the install script
-      shell: rm dotnet-install.sh
-    - name: Create symbolic link
-      shell: ln -s /Users/{{ param_user }}/.dotnet/dotnet /usr/local/bin/dotnet
-
     #
     # Setup Bitrise specific folders
     #


### PR DESCRIPTION
Installation of .Net Core right now is still a bit "beta", we'll consider pre-installing .Net Core
in the future again once it lands in `brew`. Until that it's way more flexible to use a Step
instead, which can be updated any time, instead of sticking to a preinstalled version
which is hard & slow to change.

Related discussion: https://github.com/bitrise-io/osx-box-bootstrap/pull/44
