### PR TITLE
Remove explicit bundler install

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -219,7 +219,7 @@
       shell: bash -l -c "gem update --system --no-document"
       when: is_incremental_setup|default(false) == false
     - name: gem install tools
-      shell: bash -l -c "gem install --no-document bundler cocoapods nomad-cli xcpretty fastlane"
+      shell: bash -l -c "gem install --no-document cocoapods nomad-cli xcpretty fastlane"
       when: is_incremental_setup|default(false) == false
     - name: bundle version
       shell: bash -l -c "bundle --version"


### PR DESCRIPTION
Bundler is a dependency of rubygems (since rubygems 2.7.x), manually running `gem install bundler` hangs the playbook for ever so we leave the default as of now.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
