### PR TITLE
Fix java install

### DIFF
--- a/java-android-playbook.yml
+++ b/java-android-playbook.yml
@@ -12,23 +12,12 @@
     - android_ndk_home: /opt/android-ndk
     - android_ndk_version: r16b
     - android_ndk_source: https://dl.google.com/android/repository/android-ndk-{{ android_ndk_version }}-darwin-x86_64.zip
-    - patch_marker: "Java8 & Android Additions"
   roles:
     - java
+    - jenv
     - android
     - tools
     - patch_bashrc
     - flutter
-
-  # This needs to be done after jEnv is installed (tools role) and .bashrc is patched (patch_bashrc role)
-  tasks:
-    - name: setup jEnv
-      shell: . /Users/{{ param_user }}/.bashrc && yes | jenv add {{ detect_java_home.stdout }}
-      register: result
-    - debug:
-        msg: "{{ result.stdout }}"
-
-    - name: set Java 8 as Global in jEnv
-      shell: jenv global 1.8
 
 ...

--- a/java-android-playbook.yml
+++ b/java-android-playbook.yml
@@ -8,10 +8,6 @@
   vars:
     - ansible_sudo_pass: vagrant
     - param_user: vagrant
-    - android_home: /usr/local/share/android-sdk
-    - android_ndk_home: /opt/android-ndk
-    - android_ndk_version: r16b
-    - android_ndk_source: https://dl.google.com/android/repository/android-ndk-{{ android_ndk_version }}-darwin-x86_64.zip
   roles:
     - java
     - jenv

--- a/roles/android/defaults/main.yml
+++ b/roles/android/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+android_home: /usr/local/share/android-sdk
+android_ndk_home: /opt/android-ndk
+android_ndk_version: r16b
+android_ndk_source: https://dl.google.com/android/repository/android-ndk-{{ android_ndk_version }}-darwin-x86_64.zip

--- a/roles/java/defaults/main.yml
+++ b/roles/java/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+openjdk_pkg_source: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.pkg

--- a/roles/java/defaults/main.yml
+++ b/roles/java/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 openjdk_pkg_source: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.pkg
+openjdk_pkg_dest: /tmp/openjdk-installer.pkg

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -37,15 +37,22 @@
     name: java
     state: absent
 
-- name: brew tap homebrew/cask-versions
-  homebrew_tap:
-    name: homebrew/cask-versions
-    state: present
+- name: Download OpenJDK 8
+  get_url:
+      url: "{{ openjdk_pkg_source }}"
+      dest: /tmp/openjdk-installer.pkg
+      owner: vagrant
+      group: admin
+      attributes: 0770
 
-- name: brew install java8
-  homebrew_cask:
-    name: java8
-    state: present
+- name: Install pkg file
+  shell: installer -pkg /tmp/openjdk-installer.pkg -target /
+  become: yes
+
+- name: Remove pkg
+  file:
+     path: /tmp/openjdk-installer.pkg
+     state: absent
 
 - name: Detect JAVA_HOME
   shell: /usr/libexec/java_home -v 1.8

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -36,22 +36,15 @@
     name: java
     state: absent
 
-- name: Download OpenJDK 8
-  get_url:
-      url: "{{ openjdk_pkg_source }}"
-      dest: "{{ openjdk_pkg_dest }}"
-      owner: "{{ param_user }}"
-      group: admin
-      attributes: 0770
+- name: brew tap AdoptOpenJDK/openjdk
+  homebrew_tap:
+    name: AdoptOpenJDK/openjdk
+    state: present
 
-- name: Install pkg file
-  shell: "installer -pkg {{ openjdk_pkg_dest }} -target /"
-  become: yes
-
-- name: Remove pkg
-  file:
-     path: "{{ openjdk_pkg_dest }}"
-     state: absent
+- name: brew cask install adoptopenjdk8
+  homebrew_cask:
+    name: adoptopenjdk8
+    state: present
 
 - name: Detect JAVA_HOME
   shell: /usr/libexec/java_home -v 1.8

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 # Java 8 install
 # We need Java 8 because sdkmanager doesn't support newer Java versions (yet)
 # Also we need to manually call launchctl because otherwise it breaks the brew uninstall task
@@ -40,18 +39,18 @@
 - name: Download OpenJDK 8
   get_url:
       url: "{{ openjdk_pkg_source }}"
-      dest: /tmp/openjdk-installer.pkg
-      owner: vagrant
+      dest: "{{ openjdk_pkg_dest }}"
+      owner: "{{ param_user }}"
       group: admin
       attributes: 0770
 
 - name: Install pkg file
-  shell: installer -pkg /tmp/openjdk-installer.pkg -target /
+  shell: "installer -pkg {{ openjdk_pkg_dest }} -target /"
   become: yes
 
 - name: Remove pkg
   file:
-     path: /tmp/openjdk-installer.pkg
+     path: "{{ openjdk_pkg_dest }}"
      state: absent
 
 - name: Detect JAVA_HOME

--- a/roles/jenv/tasks/main.yml
+++ b/roles/jenv/tasks/main.yml
@@ -27,7 +27,7 @@
   register: result
 
 - debug:
-  msg: "{{ result.stdout }}"
+    msg: "{{ result.stdout }}"
 
 - name: set Java 8 as Global in jEnv
   shell: jenv global 1.8

--- a/roles/jenv/tasks/main.yml
+++ b/roles/jenv/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+
+# Install jenv
+
+- name: brew install jEnv
+  homebrew:
+    name: jenv
+    state: present
+
+- name: Patch .bashrc
+  become: yes
+  blockinfile:
+    insertbefore: "keep a newline"
+    path: /Users/{{ param_user }}/.bashrc
+    block: "{{ lookup('template', 'patch.j2') }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - jEnv Additions"
+
+- name: Final newline
+  become: yes
+  lineinfile:
+    insertbefore: "keep a newline"
+    path: /Users/{{ param_user }}/.bashrc
+    line: ""
+
+- name: setup jEnv
+  shell: . /Users/{{ param_user }}/.bashrc && yes | jenv add {{ detect_java_home.stdout }}
+  register: result
+
+- debug:
+  msg: "{{ result.stdout }}"
+
+- name: set Java 8 as Global in jEnv
+  shell: jenv global 1.8
+
+...

--- a/roles/jenv/templates/patch.j2
+++ b/roles/jenv/templates/patch.j2
@@ -1,0 +1,2 @@
+export PATH=$PATH:$HOME/.jenv/bin
+eval "$(jenv init -)"

--- a/roles/patch_bashrc/tasks/main.yml
+++ b/roles/patch_bashrc/tasks/main.yml
@@ -8,7 +8,7 @@
     insertbefore: "keep a newline"
     path: /Users/{{ param_user }}/.bashrc
     block: "{{ lookup('template', 'patch.j2') }}"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK - {{ patch_marker }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - Android Additions"
 
 - name: Final newline
   become: yes

--- a/roles/patch_bashrc/templates/patch.j2
+++ b/roles/patch_bashrc/templates/patch.j2
@@ -2,11 +2,8 @@ export PATH=$PATH:{{ android_ndk_home }}
 export PATH=$PATH:{{ android_home }}/tools
 export PATH=$PATH:{{ android_home }}/tools/bin
 export PATH=$PATH:{{ android_home }}/platform-tools
-export PATH=$PATH:$HOME/.jenv/bin
 
 export ANDROID_SDK_ROOT={{ android_home }}
 export ANDROID_HOME={{ android_home }}
 export ANDROID_NDK_VERSION={{ android_ndk_version }}
 export ANDROID_NDK_HOME={{ android_ndk_home }}/android-ndk-{{ android_ndk_version }}
-
-eval "$(jenv init -)"

--- a/roles/tools/tasks/main.yml
+++ b/roles/tools/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 
-# Install additional tools
-
-- name: brew install jEnv
-  homebrew:
-    name: jenv
-    state: present
+# Install additional android/java tools
 
 - name: brew install Ant
   homebrew:

--- a/xamarin-playbook.yml
+++ b/xamarin-playbook.yml
@@ -10,6 +10,8 @@
     - ansible_sudo_pass: vagrant
     - param_user: vagrant
   roles:
+    - java
+    - jenv
     - flutter
   tasks:
     #
@@ -33,24 +35,6 @@
         dest="/Users/{{ param_user }}/.profiles/xamarin_profile"
         owner="{{ param_user }}"
         mode=0600
-
-    # Java 8 install
-    # We need Java 8 because sdkmanager doesn't support newer Java versions (yet)
-    # Also we need to manually call launchctl because otherwise it breaks the brew uninstall task
-    - name: Stop Java's Helper-Tool
-      shell: launchctl remove com.oracle.java.Helper-Tool
-      become: yes
-      ignore_errors: yes
-    - name: Stop Java's Java-Updater
-      shell: launchctl remove com.oracle.java.Java-Updater
-      become: yes
-      ignore_errors: yes
-    - name: brew uninstall latest java
-      homebrew_cask: name=java state=absent
-    - name: brew tap homebrew/cask-versions
-      homebrew_tap: name='homebrew/cask-versions' state=present
-    - name: brew install java8
-      homebrew_cask: name=java8 state=present
 
     # ------------------------------------------------------
     # --- Install Android SDKs and other build packages


### PR DESCRIPTION
We cannot install OracleJDK from brew anymore because Oracle & Java licensing changes. This PR is for switching to an AdoptOpenJDK packaged version.