### PR TITLE
Removed ruby version 2.2.10 and 2.3.8 because they no longer can be i…

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -10,7 +10,7 @@
   vars:
     - ansible_sudo_pass: vagrant
     - param_user: vagrant
-    - default_ruby: 2.6.3
+    - default_ruby: 2.6.5
   roles:
     - ssh-setup
     - profiles

--- a/roles/intermediate-setup/tasks/main.yml
+++ b/roles/intermediate-setup/tasks/main.yml
@@ -116,12 +116,7 @@
 - name: Install ruby 2.4.6
   shell: bash -l -c "rbenv install --skip-existing 2.4.6"
   when: is_incremental_setup|default(false) == false
-- name: Install ruby 2.3.8
-  shell: bash -l -c "rbenv install --skip-existing 2.3.8"
-  when: is_incremental_setup|default(false) == false
-- name: Install ruby 2.2.10
-  shell: bash -l -c "rbenv install --skip-existing 2.2.10"
-  when: is_incremental_setup|default(false) == false
+
 
 ## Go
 # Gopath is $HOME/go

--- a/roles/intermediate-setup/tasks/main.yml
+++ b/roles/intermediate-setup/tasks/main.yml
@@ -110,11 +110,11 @@
 - name: Set ruby {{ default_ruby }} to global
   shell: bash -l -c "rbenv global {{ default_ruby }}"
   when: is_incremental_setup|default(false) == false
-- name: Install ruby 2.5.5
-  shell: bash -l -c "rbenv install --skip-existing 2.5.5"
+- name: Install ruby 2.5.7
+  shell: bash -l -c "rbenv install --skip-existing 2.5.7"
   when: is_incremental_setup|default(false) == false
-- name: Install ruby 2.4.6
-  shell: bash -l -c "rbenv install --skip-existing 2.4.6"
+- name: Install ruby 2.4.9
+  shell: bash -l -c "rbenv install --skip-existing 2.4.9"
   when: is_incremental_setup|default(false) == false
 
 


### PR DESCRIPTION
…nstalled on this OS version

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
