### PR TITLE
it seems the latest ruby is indeed 2.5.6 but from rbenv you only can …

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -10,7 +10,7 @@
   vars:
     - ansible_sudo_pass: vagrant
     - param_user: vagrant
-    - default_ruby: 2.6.5
+    - default_ruby: 2.6.3
   roles:
     - ssh-setup
     - profiles


### PR DESCRIPTION
…install 2.6.3

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
