### PR TITLE
Removing deprecated cocoapods version (<1.0) related weekly update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## UPCOMING
 
+## `v2019_11_06_1`
+* `removed deprecated cocoapods version (<1.0) related weekly update`
 
 ## `v2019_11_05_1`
 * `implemented a bugfix for the recent CocoaPods specs install issue`

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,6 +1,6 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
-export BITRISE_OSX_STACK_REV_ID=v2019_11_05_1
+export BITRISE_OSX_STACK_REV_ID=v2019_11_06_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -88,15 +88,6 @@
 
 - name: "CocoaPods: pod setup"
   shell: bash -l -c "pod setup || pod setup"
-  when: use_deprecated_cocoapods|default("") != "yes"
-# For deprecated CocoaPods versions
-# See: http://blog.cocoapods.org/Sharding/
-- name: "CocoaPods: checkout spec repo - for deprecated cocoapods versions"
-  shell: bash -l -c "cd /Users/vagrant/.cocoapods/repos/master/ && git fetch origin master --tags && git checkout v0.32.1"
-  when: use_deprecated_cocoapods|default("") == "yes"
-- name: "CocoaPods: pre-fetch the Old-Specs spec, to update it to the latest version"
-  shell: bash -l -c "pod repo add cocoapods https://github.com/CocoaPods/Old-Specs"
-  when: use_deprecated_cocoapods|default("") == "yes"
 
 
 # ----------------------------------------


### PR DESCRIPTION
We no longer have any stacks with CocoaPods <1.0 installed, even Xcode 8.3 stack has 1.2.1 on it https://github.com/bitrise-io/bitrise.io/blob/master/system_reports/osx-xcode-8.3.x.log#L64

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
