### PR TITLE
Add support for Firebase CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2019_11_07_1`
+* `firebase`: `7.6.2`
+
 ## `v2019_11_06_1`
 * `removed deprecated cocoapods version (<1.0) related weekly update`
 

--- a/roles/intermediate-setup/tasks/main.yml
+++ b/roles/intermediate-setup/tasks/main.yml
@@ -100,6 +100,11 @@
 
 - name: brew install java
   homebrew_cask: name=java state=present
+  
+  
+- name: "Firebase (CLI)"
+  shell: curl -sL firebase.tools | bash
+  become: yes
 
 # Ruby
 - name: brew install rbenv

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,6 +1,6 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
-export BITRISE_OSX_STACK_REV_ID=v2019_11_06_1
+export BITRISE_OSX_STACK_REV_ID=v2019_11_07_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -131,6 +131,9 @@
 - name: "cmd-bridge -version"
   shell: bash -l -c "cmd-bridge --version"
 
+- name: "firebase (CLI)"
+  shell: curl -sL firebase.tools | bash
+
 
 # ----------------------------------------
 # --- Cleanup ---

--- a/system_report.sh
+++ b/system_report.sh
@@ -60,14 +60,15 @@ if [[ "${IS_IGNORE_ERRORS}" != "true" ]] ; then
 set -e
 fi
 
-ver_line="$(ansible --version | grep ansible)" ;  echo "* Ansible: $ver_line"
-ver_line="$(gtimeout --version | grep 'timeout')" ;  echo "* gtimeout: $ver_line"
-ver_line="$(watchman --version)" ;                echo "* watchman: $ver_line"
-ver_line="$(flow version)" ;                      echo "* flow: $ver_line"
-ver_line="$(carthage version)" ;                  echo "* carthage: $ver_line"
-ver_line="$(convert --version | head -1)" ;       echo "* imagemagick (convert): $ver_line"
-ver_line="$(ps2ascii --version)" ;                echo "* ghostscript (ps2ascii): $ver_line"
-ver_line="$(screen --version | grep Screen)" ;    echo "* screen: $ver_line"
+ver_line="$(ansible --version | grep ansible)" ;      echo "* Ansible: $ver_line"
+ver_line="$(gtimeout --version | grep 'timeout')" ;   echo "* gtimeout: $ver_line"
+ver_line="$(watchman --version)" ;                    echo "* watchman: $ver_line"
+ver_line="$(flow version)" ;                          echo "* flow: $ver_line"
+ver_line="$(carthage version)" ;                      echo "* carthage: $ver_line"
+ver_line="$(convert --version | head -1)" ;           echo "* imagemagick (convert): $ver_line"
+ver_line="$(ps2ascii --version)" ;                    echo "* ghostscript (ps2ascii): $ver_line"
+ver_line="$(screen --version | grep Screen)" ;        echo "* screen: $ver_line"
+ver_line="$(firebase --version)" ;                    echo "* firebase: $ver_line"
 
 # wine was removed, not installed on new Stacks
 set +e


### PR DESCRIPTION
The Firebase CLI ([GitHub](https://github.com/firebase/firebase-tools)) provides a variety of tools for managing, viewing, and deploying to Firebase projects.

Add support for Firebase CLI - https://firebase.google.com/docs/app-distribution/ios/distribute-cli

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md