### PR TITLE
fix swift-sh brew install path, install on Xcode 9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## v2019_11_14_1
+* `fix swift-sh brew install path, install on Xcode 9+`
+
 ## v2019_11_13_2
 * `removed old android emulators up to api level 25`
 

--- a/roles/intermediate-setup/tasks/main.yml
+++ b/roles/intermediate-setup/tasks/main.yml
@@ -107,8 +107,13 @@
   become: yes
 
 # Swift Tools
-- name: brew install mxcl/made/swift-sh
-  homebrew: name=swift-sh state=present
+- name: register xcode version
+  shell: /usr/bin/xcodebuild -version | grep Xcode | awk '{print $2}'
+  register: xcode_version
+
+- name: brew install swift-sh
+  homebrew: name=mxcl/made/swift-sh state=present
+  when: xcode_version|int > 9
 
 # Ruby
 - name: brew install rbenv

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2019_11_13_2
+export BITRISE_OSX_STACK_REV_ID=v2019_11_14_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -129,9 +129,15 @@
   file: path=/usr/local/bin/cmd-bridge mode="u=rwx,g=rx,o=rx"
 - name: "cmd-bridge -version"
   shell: bash -l -c "cmd-bridge --version"
-  
-- name: brew install mxcl/made/swift-sh
-  homebrew: name=swift-sh state=latest
+
+
+- name: register xcode version
+  shell: /usr/bin/xcodebuild -version | grep Xcode | awk '{print $2}'
+  register: xcode_version
+
+- name: brew install swift-sh
+  homebrew: name=mxcl/made/swift-sh state=latest
+  when: xcode_version|int > 9
 
 
 - name: "firebase (CLI)"


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md