### PR TITLE
[IN-0] remove vagrant-setup, the playbook has been deleted in mid 2019

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,10 +8,8 @@ app:
   - XCODE_PATH: $XCODE_PATH
 trigger_map:
 - push_branch: step/1
-  workflow: vagrant-setup
-- push_branch: step/2
   workflow: provision-vm
-- push_branch: step/3
+- push_branch: step/2
   workflow: perform-weekly-cache-update
 - push_branch: step/xamarin
   workflow: provision-xamarin-vm
@@ -132,21 +130,6 @@ workflows:
             set -e
             set -x
             ansible-playbook -v --private-key ./vagrant-insecure_private_key -i "${VM_BUILD_IP}", "./xamarin-playbook.yml"
-
-  vagrant-setup:
-    description: |-
-      Runs `ansible` with the `vagrant-setup-playbook`, to have a bare minimum
-      `vagrant` ready setup on the target VM.
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -e
-            echo " (!!!) When prompted for a password provide the VM's SSH password"
-            echo '       should be "vagrant" if you do a default vagrant setup'
-            set -x
-            ansible-playbook -v --ask-pass -i "${VM_BUILD_IP}", "./vagrant-setup-playbook.yml"
 
   _ansible-play:
     steps:


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md