### PR TITLE
[Tool-2251] Add Go isntall to weekly update

### DIFF
--- a/roles/intermediate-setup/tasks/main.yml
+++ b/roles/intermediate-setup/tasks/main.yml
@@ -110,22 +110,6 @@
   shell: bash -l -c "curl -sL firebase.tools | bash"
   become: yes
 
-## Go
-# Gopath is $HOME/go
-- name: brew install go
-  homebrew:
-    name: go
-    state: present
-- name: prepare GOPATH dirs
-  file:
-    path: "/Users/{{ param_user }}/go/{{ item.fold_path }}"
-    state: directory
-    owner: "{{ param_user }}"
-  with_items:
-    - { fold_path: 'src' }
-    - { fold_path: 'bin' }
-    - { fold_path: 'pkg' }
-
 # NPM global packages
 - name: Install "ionic", "cordova" and "appcenter-cli" NodeJS packages globally
   shell: bash -l -c "npm install -g ionic cordova appcenter-cli"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -31,6 +31,22 @@
     mode: "0644"
   become: yes
 
+## Go
+# Gopath is $HOME/go
+- name: brew install go
+  homebrew:
+    name: go
+    state: present
+- name: prepare GOPATH dirs
+  file:
+    path: "/Users/{{ param_user }}/go/{{ item.fold_path }}"
+    state: directory
+    owner: "{{ param_user }}"
+  with_items:
+    - { fold_path: 'src' }
+    - { fold_path: 'bin' }
+    - { fold_path: 'pkg' }
+
 # ----------------------------------------
 # --- remote access script install ---
 # ----------------------------------------


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md