### PR TITLE
[IN-1551] Remove Ruby from base builder creation, and remove quickfix

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -13,6 +13,5 @@
   roles:
     - ssh-setup
     - profiles
-    - ruby
     - intermediate-setup
     - node

--- a/roles/ruby/tasks/ruby.yml
+++ b/roles/ruby/tasks/ruby.yml
@@ -29,9 +29,6 @@
 - name: CocoaPods specs install with pod
   shell: bash -l -c "pod repo add master https://github.com/CocoaPods/Specs.git"
   when: is_incremental_setup|default(false) == false and not lookup('env', 'IS_CI')
-  ignore_errors: true
-  # on base builder creation this fails because it is already there.
-  # we can remove this role from base builder creation when the new stable xcode comes out.
 
 # The pod repo add just clone the repository.
 # Cocopods master is huge, and we need the HEAD only so we clone that during CI run.


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md