### PR TITLE
[IN-1560] we don't use the .sh extension under profile.d follow it up in bashrc

### DIFF
--- a/roles/profiles/files/bashrc
+++ b/roles/profiles/files/bashrc
@@ -38,7 +38,7 @@ if [ -s "$HOME/.profiles/xamarin_profile" ] ; then
   source "$HOME/.profiles/xamarin_profile"
 fi
 
-for PROFILE_SCRIPT in $( ls $HOME/profile.d/*.sh ); do
+for PROFILE_SCRIPT in $( ls $HOME/profile.d/* ); do
   . $PROFILE_SCRIPT
 done
 

--- a/system_report.sh
+++ b/system_report.sh
@@ -255,8 +255,7 @@ if [ -n "$ANDROID_HOME" ] ; then
   fi
   echo
   echo "* platform-tools content:"
-  ##ls -1 ${ANDROID_HOME}/platform-tools changed to brew
-  ls -1 /usr/local/Caskroom/android-platform-tools/*/platform-tools
+  ls -1 ${ANDROID_HOME}/platform-tools
   echo
   echo "* build-tools content:"
   ls -1 ${ANDROID_HOME}/build-tools


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md