### PR TITLE
Upgrade Flutter SDK to 1.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2020_08_20_1`
+* `flutter`: `1.20.2`
+
 ## `v2020_06_10_1`
 * `explicitly install bundler at v2.1.4`
 

--- a/roles/flutter/defaults/main.yml
+++ b/roles/flutter/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-flutter_version: 1.17.1
+flutter_version: 1.20.2
 flutter_home: /usr/local

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2020_06_10_1
+export BITRISE_OSX_STACK_REV_ID=v2020_08_20_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"


### PR DESCRIPTION
We would like to upgrade Flutter SDK to the latest stable version.
- [Flutter SDK releases](https://flutter.dev/docs/development/tools/sdk/releases)
- [Changelog 1.20.2](https://github.com/flutter/flutter/releases/tag/1.20.2)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md