### PR TITLE
[IN-1719]: revert java 11 0 upgrade to not break gradle

### DIFF
--- a/roles/android/tasks/main.yml
+++ b/roles/android/tasks/main.yml
@@ -14,7 +14,7 @@
     src: "{{ android_ndk_source }}"
     dest: "{{ android_ndk_home }}"
     owner: "{{ param_user }}"
-    mode: "0770"
+    mode: 0770
     remote_src: true
 
 - name: Create profile.d directory
@@ -43,7 +43,6 @@
     src: "{{ android_cmdline_tools_source }}"
     dest: "{{ android_home }}/cmdline-tools/"
     remote_src: true
-    mode: "0755"
 
 - name: Ensure .android directory exists
   file:
@@ -60,8 +59,8 @@
 - name: Install Android packages with SDK Manager
   become: true
   environment:
-    PATH: "{{ android_home }}/cmdline-tools/tools/bin:{{ ansible_env.PATH }}"
-  shell: "(echo y | sdkmanager --verbose '{{ item }}')"  # noqa 204 306
+    PATH: "{{ android_home }}/tools/bin:{{ android_home }}/cmdline-tools/tools/bin:{{ ansible_env.PATH }}"
+  shell: "(echo y | sdkmanager --verbose '{{ item }}') || (echo y | sdkmanager --verbose '{{ item }}')"  # noqa 204 306
   with_items:
     - "{{ sdkmanagerpackages }}"
   args:

--- a/roles/android/templates/patch.j2
+++ b/roles/android/templates/patch.j2
@@ -1,6 +1,8 @@
 export PATH=$PATH:{{ android_ndk_home }}
+export PATH=$PATH:{{ android_home }}/tools
+export PATH=$PATH:{{ android_home }}/tools/bin
 export PATH=$PATH:{{ android_home }}/platform-tools
-export PATH=$PATH:{{ android_home }}/cmdline-tools/tools/bin
+export PATH=$PATH:{{ android_home }}/cmdline-tools/latest/tools/bin
 
 export ANDROID_SDK_ROOT={{ android_home }}
 export ANDROID_HOME={{ android_home }}

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -48,18 +48,13 @@
     name: bitrise-io/cask-versions
     state: present
 
-- name: brew tap openjdk library
-  homebrew_tap:
-    name: AdoptOpenJDK/openjdk
-    state: present
-
-- name: brew cask install adoptopenjdk11
+- name: brew cask install adoptopenjdk8
   homebrew_cask:
-    name: adoptopenjdk11
+    name: adoptopenjdk8
     state: present
 
 - name: Detect JAVA_HOME
-  shell: /usr/libexec/java_home -v 11
+  shell: /usr/libexec/java_home -v 1.8
   register: detect_java_home
   ignore_errors: true
 

--- a/roles/jenv/tasks/main.yml
+++ b/roles/jenv/tasks/main.yml
@@ -24,6 +24,6 @@
     msg: "{{ result.stdout }}"
 
 - name: set Java 11 as Global in jEnv
-  shell: bash -l -c "jenv global 11.0"
+  shell: bash -l -c "jenv global 11"
 
 ...

--- a/roles/jenv/tasks/main.yml
+++ b/roles/jenv/tasks/main.yml
@@ -13,7 +13,7 @@
     src: patch.j2
     dest: /Users/{{ param_user }}/profile.d/jenv.sh
     owner: "{{ param_user }}"
-    mode: "0755"
+    mode: 0755
 
 - name: setup jEnv  # noqa 306 Shells that use pipes should set the pipefail option
   shell: . /Users/{{ param_user }}/.bashrc && (yes | jenv add {{ detect_java_home.stdout }})
@@ -23,7 +23,7 @@
   debug:
     msg: "{{ result.stdout }}"
 
-- name: set Java 11 as Global in jEnv
-  shell: bash -l -c "jenv global 11"
+- name: set Java 8 as Global in jEnv
+  shell: bash -l -c "jenv global 1.8"
 
 ...


### PR DESCRIPTION
Currently, gradle breaks with this version. We must upgrade next week.

Reverted PR: 
 - https://github.com/bitrise-io/osx-box-bootstrap/commit/5290c50d
 - https://github.com/bitrise-io/osx-box-bootstrap/pull/293