### PR TITLE
[IN-1842] Install Java 11 but keep Java 8 as default

### DIFF
--- a/roles/android/tasks/main.yml
+++ b/roles/android/tasks/main.yml
@@ -14,7 +14,7 @@
     src: "{{ android_ndk_source }}"
     dest: "{{ android_ndk_home }}"
     owner: "{{ param_user }}"
-    mode: 0770
+    mode: "0770"
     remote_src: true
 
 - name: Create profile.d directory
@@ -36,6 +36,7 @@
   file:
     dest: "{{ android_home }}/cmdline-tools/"
     state: directory
+    mode: "0755"
 
 - name: Download and extract command-line tools for Android
   become: true
@@ -59,8 +60,8 @@
 - name: Install Android packages with SDK Manager
   become: true
   environment:
-    PATH: "{{ android_home }}/tools/bin:{{ android_home }}/cmdline-tools/tools/bin:{{ ansible_env.PATH }}"
-  shell: "(echo y | sdkmanager --verbose '{{ item }}') || (echo y | sdkmanager --verbose '{{ item }}')"  # noqa 204 306
+    PATH: "{{ android_home }}/cmdline-tools/tools/bin:{{ ansible_env.PATH }}"
+  shell: "(echo y | sdkmanager --verbose '{{ item }}')"  # noqa 204 306
   with_items:
     - "{{ sdkmanagerpackages }}"
   args:

--- a/roles/android/templates/patch.j2
+++ b/roles/android/templates/patch.j2
@@ -1,8 +1,6 @@
 export PATH=$PATH:{{ android_ndk_home }}
-export PATH=$PATH:{{ android_home }}/tools
-export PATH=$PATH:{{ android_home }}/tools/bin
 export PATH=$PATH:{{ android_home }}/platform-tools
-export PATH=$PATH:{{ android_home }}/cmdline-tools/latest/tools/bin
+export PATH=$PATH:{{ android_home }}/cmdline-tools/tools/bin
 
 export ANDROID_SDK_ROOT={{ android_home }}
 export ANDROID_HOME={{ android_home }}

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -48,9 +48,14 @@
     name: bitrise-io/cask-versions
     state: present
 
+- name: brew tap openjdk library
+  homebrew_tap:
+    name: AdoptOpenJDK/openjdk
+    state: present
+
 - name: brew cask install adoptopenjdk8
   homebrew_cask:
-    name: adoptopenjdk8
+    name: adoptopenjdk11
     state: present
 
 - name: Detect JAVA_HOME

--- a/roles/jenv/tasks/main.yml
+++ b/roles/jenv/tasks/main.yml
@@ -13,7 +13,7 @@
     src: patch.j2
     dest: /Users/{{ param_user }}/profile.d/jenv.sh
     owner: "{{ param_user }}"
-    mode: 0755
+    mode: "0755"
 
 - name: setup jEnv  # noqa 306 Shells that use pipes should set the pipefail option
   shell: . /Users/{{ param_user }}/.bashrc && (yes | jenv add {{ detect_java_home.stdout }})


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md