### PR TITLE
[IN-1877] Install python3.8, molecule breaks on python3.5

### DIFF
--- a/_scripts/install_molecule_dependencies.sh
+++ b/_scripts/install_molecule_dependencies.sh
@@ -9,15 +9,22 @@ if [[ "$os" == "Darwin" ]]; then
     molecule_version="$(molecule --version | sed -n 1p)"
     echo "Successfully installed $molecule_version"
 else
+    #TODO: ugly hack to use molecule till we not switch to virtualenv
+    #build runs in ubuntu 16.04, python 3.5 is installed there, but it is not compatible with molecule
+    add-apt-repository -y ppa:deadsnakes/ppa
+
     echo "Updating apt..."
     apt-get update &>/dev/null
 
-    echo "Install apt dependencies..."
-    apt-get install -y build-essential libssl-dev libffi-dev python-dev &>"$BITRISE_DEPLOY_DIR"/apt_install.log
+    apt-get install -y python3.8 python3.8-dev python3.8-venv
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
+    update-alternatives --set python3 /usr/bin/python3.8
+    curl https://bootstrap.pypa.io/get-pip.py | python3.8
 
-    echo "Install pip3..."
-    apt install -y python3-pip &>/dev/null
-    pip install --upgrade pip &>/dev/null
+    echo "Install apt dependencies..."
+    apt-get install -y build-essential libssl-dev libffi-dev &>"$BITRISE_DEPLOY_DIR"/apt_install.log
+
     pip_version="$(pip --version | awk '{print $1, $2}')"
     echo "Installed $pip_version"
 

--- a/ansible-lint.yaml
+++ b/ansible-lint.yaml
@@ -2,6 +2,7 @@
 # We are skipping these Ansible-lint rules
 # For more information consult the documentation https://docs.ansible.com/ansible-lint/rules/rules.html
 skip_list:
+    - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
     - '204'  # Lines should be no longer than 160 chars, we validate it with yamllint
     - '301'  # Commands should not change things if nothing needs doing
     - '305'  # Use shell only when shell functionality is required

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -87,7 +87,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -e
-            sudo pip3 install "ansible-lint==${ANSIBLE_LINT_VER}" --force-reinstall
+            sudo pip3 install ansible-lint
             ansible-lint --version
     - script:
         title: Install yamllint ver = YAML_LINT_VER


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md