### PR TITLE
[IN-2117] disable homebrew install cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2020_11_03_1`
+* `disable homebrew install cleanup`
+
 ## `v2020_10_27_1`
 * `install cocoapods to the latest`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## UPCOMING
 
 ## `v2020_11_03_1`
-* `disable homebrew install cleanup`
+* `disable the execution of brew cleanup during install`
 
 ## `v2020_10_27_1`
 * `install cocoapods to the latest`

--- a/roles/brew-cleanup-weekly/tasks/main.yml
+++ b/roles/brew-cleanup-weekly/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Brew cleanup weekly
-  shell: brew cleanup
+  shell: /usr/local/bin/brew cleanup

--- a/roles/brew-cleanup-weekly/tasks/main.yml
+++ b/roles/brew-cleanup-weekly/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Brew cleanup weekly
+  shell: brew cleanup

--- a/roles/profiles/files/bashrc
+++ b/roles/profiles/files/bashrc
@@ -8,6 +8,8 @@ export LANGUAGE="en_US.UTF-8"
 #  Don't do auto update
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
+# Don't do install cleanup
+export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go
 export PATH="$PATH:/usr/local/opt/go/libexec/bin"

--- a/roles/profiles/files/bashrc
+++ b/roles/profiles/files/bashrc
@@ -8,7 +8,7 @@ export LANGUAGE="en_US.UTF-8"
 #  Don't do auto update
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
-# Don't do install cleanup
+
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go

--- a/roles/profiles/files/bashrc
+++ b/roles/profiles/files/bashrc
@@ -8,7 +8,6 @@ export LANGUAGE="en_US.UTF-8"
 #  Don't do auto update
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
-
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2020_10_27_1
+export BITRISE_OSX_STACK_REV_ID=v2020_11_03_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2020_11_03_1
+export BITRISE_OSX_STACK_REV_ID=v2020_11_04
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/profiles/files/zshrc
+++ b/roles/profiles/files/zshrc
@@ -7,7 +7,7 @@ export LANGUAGE="en_US.UTF-8"
 #  Don't do auto update
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
-# Don't do install cleanup
+
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go

--- a/roles/profiles/files/zshrc
+++ b/roles/profiles/files/zshrc
@@ -7,6 +7,8 @@ export LANGUAGE="en_US.UTF-8"
 #  Don't do auto update
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
+# Don't do install cleanup
+export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go
 export PATH="$PATH:/usr/local/opt/go/libexec/bin"

--- a/roles/profiles/files/zshrc
+++ b/roles/profiles/files/zshrc
@@ -7,7 +7,6 @@ export LANGUAGE="en_US.UTF-8"
 #  Don't do auto update
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_ANALYTICS=1
-
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -102,6 +102,16 @@
 #     (built during Stack prepare, to validate the Xcode setup)
 #  * Xcode "components" (simulators) installer Download Cache dir:
 #     Xcode stores the simulator installers here, and it never cleans them up for some reason.
+
+- name: Disable homebrew install cleanup in zshrc
+  lineinfile:
+    path: ~/.zshrc
+    line: export HOMEBREW_NO_INSTALL_CLEANUP=1
+- name: Disable homebrew install cleanup in bashrc
+  lineinfile:
+    path: ~/.bashrc
+    line: export HOMEBREW_NO_INSTALL_CLEANUP=1
+
 - name: Remove tmp and test dirs inside the HOME directory
   file:
     path: "$HOME/{{ item.fold_path }}"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -103,15 +103,6 @@
 #  * Xcode "components" (simulators) installer Download Cache dir:
 #     Xcode stores the simulator installers here, and it never cleans them up for some reason.
 
-- name: Disable homebrew install cleanup in zshrc
-  lineinfile:
-    path: ~/.zshrc
-    line: export HOMEBREW_NO_INSTALL_CLEANUP=1
-- name: Disable homebrew install cleanup in bashrc
-  lineinfile:
-    path: ~/.bashrc
-    line: export HOMEBREW_NO_INSTALL_CLEANUP=1
-
 - name: Remove tmp and test dirs inside the HOME directory
   file:
     path: "$HOME/{{ item.fold_path }}"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -114,4 +114,3 @@
 - name: Brew cleanup weekly
   include_role:
     name: brew-cleanup-weekly
-    tasks_from: main

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -110,3 +110,8 @@
   with_items:
     - { fold_path: 'Library/Developer/Xcode/DerivedData' }
     - { fold_path: 'Library/Caches/com.apple.dt.Xcode/Downloads' }
+
+- name: Brew cleanup weekly
+  include_role:
+    name: brew-cleanup-weekly
+    tasks_from: main


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md