### PR TITLE
[IN-2270] cocoapods 1.8 and up defaults to CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2020_12_08`
+* `Removed Specs repo master, for it is not necessary from 1.8 and up`
+
 ## `v2020_12_03`
 * `Sample ios and macos automated tests`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2020_12_03
+export BITRISE_OSX_STACK_REV_ID=v2020_12_08
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/ruby-gems/tasks/main.yml
+++ b/roles/ruby-gems/tasks/main.yml
@@ -14,17 +14,8 @@
   with_items:
     - "{{ gem_packages }}"
 
-# GEMs: Cocoapods
+# GEMs: Cocoapods setup
 - name: pod setup
-  shell: bash -l -c "pod setup || pod setup"
+  shell: bash -l -c "pod setup"
+  retries: 3
   when: is_incremental_setup|default(false) == false
-
-- name: CocoaPods specs install with pod
-  shell: bash -l -c "pod repo add master https://github.com/CocoaPods/Specs.git || pod repo update master"
-  when: is_incremental_setup|default(false) == false and not lookup('env', 'IS_CI')
-
-# The pod repo add just clone the repository.
-# Cocopods master is huge, and we need the HEAD only so we clone that during CI run.
-- name: CocoaPods specs install with git
-  shell: bash -l -c "git clone --depth=1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master ||  git -C ~/.cocoapods/repos/master pull --ff-only --depth=1"
-  when: is_incremental_setup|default(false) == false and lookup('env', 'IS_CI')

--- a/roles/ruby-gems/tasks/main.yml
+++ b/roles/ruby-gems/tasks/main.yml
@@ -19,3 +19,6 @@
   shell: bash -l -c "pod setup"
   retries: 3
   when: is_incremental_setup|default(false) == false
+
+- name: "CocoaPods: pod repo update"
+  shell: bash -l -c "pod repo update"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -45,7 +45,8 @@
 # ----------------------------------------
 
 - name: "CocoaPods: pod setup"
-  shell: bash -l -c "pod setup || pod setup"
+  shell: bash -l -c "pod setup"
+  retries: 3
 - name: "CocoaPods: pod repo update"
   shell: bash -l -c "pod repo update"
 

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -44,12 +44,6 @@
 # --- pre-installed tool cache updates ---
 # ----------------------------------------
 
-- name: "CocoaPods: pod setup"
-  shell: bash -l -c "pod setup"
-  retries: 3
-- name: "CocoaPods: pod repo update"
-  shell: bash -l -c "pod repo update"
-
 # curl used in place of get_url or uri module
 # Shells that use pipes should set the pipefail option
 - name: "firebase (CLI)"  # noqa 303 306


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I updated the corresponding tests if there were any.
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md