### PR TITLE
[IN-0]: Revert "[IN-2270] cocoapods 1.8 and up defaults to CDN (#348)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## UPCOMING
 
+## `v2021_01_12`
+* `Revert: Removed Specs repo master, for it is not necessary from 1.8 and up`
 ## `v2021_01_08`
 * `brew install fixes`
 

--- a/roles/ruby-gems/tasks/main.yml
+++ b/roles/ruby-gems/tasks/main.yml
@@ -14,11 +14,17 @@
   with_items:
     - "{{ gem_packages }}"
 
-# GEMs: Cocoapods setup
+# GEMs: Cocoapods
 - name: pod setup
-  shell: bash -l -c "pod setup"
-  retries: 3
+  shell: bash -l -c "pod setup || pod setup"
   when: is_incremental_setup|default(false) == false
 
-- name: "CocoaPods: pod repo update"
-  shell: bash -l -c "pod repo update"
+- name: CocoaPods specs install with pod
+  shell: bash -l -c "pod repo add master https://github.com/CocoaPods/Specs.git || pod repo update master"
+  when: is_incremental_setup|default(false) == false and not lookup('env', 'IS_CI')
+
+# The pod repo add just clone the repository.
+# Cocopods master is huge, and we need the HEAD only so we clone that during CI run.
+- name: CocoaPods specs install with git
+  shell: bash -l -c "git clone --depth=1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master ||  git -C ~/.cocoapods/repos/master pull --ff-only --depth=1"
+  when: is_incremental_setup|default(false) == false and lookup('env', 'IS_CI')

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -44,6 +44,11 @@
 # --- pre-installed tool cache updates ---
 # ----------------------------------------
 
+- name: "CocoaPods: pod setup"
+  shell: bash -l -c "pod setup || pod setup"
+- name: "CocoaPods: pod repo update"
+  shell: bash -l -c "pod repo update"
+
 # curl used in place of get_url or uri module
 # Shells that use pipes should set the pipefail option
 - name: "firebase (CLI)"  # noqa 303 306


### PR DESCRIPTION
This reverts commit 3550c3038239d55fc1d44312d72b3f36a94d17ae.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md