### PR TITLE
[IN-2474] place the ssh pub key on the remote build artifact

### DIFF
--- a/roles/baseos/tasks/main.yml
+++ b/roles/baseos/tasks/main.yml
@@ -100,3 +100,12 @@
   become: true
   command: pmset -a hibernatemode 0
   when: hibernate_state.rc == 1
+
+# This key must exists on the executing ansible server
+# For CI, it is placed from bitrise secrets in the workflow
+# For local, you must install it from lastpass
+- name: install the build SSH key
+  ansible.posix.authorized_key:
+    user: vagrant
+    state: present
+    key: "{{ lookup('file', lookup('env', 'HOME') + '/.ssh/id_ed25519-bitrise.pub') }}"

--- a/roles/baseos/tasks/main.yml
+++ b/roles/baseos/tasks/main.yml
@@ -101,7 +101,7 @@
   command: pmset -a hibernatemode 0
   when: hibernate_state.rc == 1
 
-# This key must exists on the executing ansible server
+# This key must exist on the executing ansible server
 # For CI, it is placed from bitrise secrets in the workflow
 # For local, you must install it from lastpass
 - name: install the build SSH key


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md