### PR TITLE
[IN-2506] android package names have ; in them, handle failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_02_24`
+* `Fix checks in android install`
+
 ## `v2021_02_19_6`
 * `Remove roles from playbook.yml that are not meant to be there`
 

--- a/roles/android/tasks/sdk-install.yml
+++ b/roles/android/tasks/sdk-install.yml
@@ -2,7 +2,7 @@
 - name: Test Android package is installed - {{ sdk }}
   environment:
     PATH: "{{ android_home }}/cmdline-tools/tools/bin:{{ ansible_env.PATH }}"
-  shell: "sdkmanager --list --verbose | awk '/Installed/,/Available' | grep {{ sdk }}"
+  shell: "sdkmanager --list --verbose | awk '/Installed/,/Available' | grep '{{ sdk }}'"
   register: is_sdk_installed
   changed_when: false
   ignore_errors: true
@@ -12,5 +12,5 @@
   environment:
     PATH: "{{ android_home }}/cmdline-tools/tools/bin:{{ ansible_env.PATH }}"
   shell: "(echo y | sdkmanager --verbose --install '{{ sdk }}')"  # noqa 204 306
-  when: is_sdk_installed.rc == 1
+  when: is_sdk_installed is failed
   retries: 3

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_02_19_6
+export BITRISE_OSX_STACK_REV_ID=v2021_02_24
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md