### PR TITLE
Upgrade Flutter SDK to 1.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_03_03_1`
+* `flutter`: `1.22.6`
+
 ## `v2021_03_02`
 * `Fix python brew linking, so python3 and pip3 are both the brew installed ones`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_02_26_1`
+* `flutter`: `1.22.6`
+
 ## `v2021_02_24`
 * `Fix checks in android install`
 

--- a/roles/flutter/defaults/main.yml
+++ b/roles/flutter/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 param_user: vagrant
 param_group: admin
-flutter_version: 1.22.1
+flutter_version: 1.22.6
 flutter_home: /usr/local

--- a/roles/flutter/tasks/main.yml
+++ b/roles/flutter/tasks/main.yml
@@ -3,7 +3,7 @@
   shell: "{{ flutter_home }}/flutter/bin/flutter --version"
   ignore_errors: true
   register: flutter_version_check
-  changed_when: "'Flutter 1.22.1' not in flutter_version_check.stdout"
+  changed_when: "'Flutter 1.22.6' not in flutter_version_check.stdout"
 
 - name: Install, configure and warmup flutter
   block:
@@ -50,5 +50,5 @@
 
   - name: Run flutter doctor
     shell: bash -l -c "{{ flutter_home }}/flutter/bin/flutter doctor"
-  when: "'Flutter 1.22.1' not in flutter_version_check.stdout"
+  when: "'Flutter 1.22.6' not in flutter_version_check.stdout"
 ...

--- a/roles/flutter/tests/test_flutter.py
+++ b/roles/flutter/tests/test_flutter.py
@@ -1,2 +1,2 @@
 def test_flutter_properly_installed(host):
-    assert "Flutter 1.22.1" in host.run("/usr/local/flutter/bin/flutter --version").stdout
+    assert "Flutter 1.22.6" in host.run("/usr/local/flutter/bin/flutter --version").stdout

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_02
+export BITRISE_OSX_STACK_REV_ID=v2021_03_03_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_02_24
+export BITRISE_OSX_STACK_REV_ID=v2021_02_26_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"


### PR DESCRIPTION
We would like to upgrade Flutter SDK to the latest stable version.

- [Flutter SDK releases](https://flutter.dev/docs/development/tools/sdk/releases)
- Changelog
  - [1.22.2](https://github.com/flutter/flutter/releases/tag/1.22.2)
  - [1.22.3](https://github.com/flutter/flutter/releases/tag/1.22.3)
  - [1.22.4](https://github.com/flutter/flutter/releases/tag/1.22.4)
  - [1.22.5](https://github.com/flutter/flutter/releases/tag/1.22.5)
  - [1.22.6](https://github.com/flutter/flutter/releases/tag/1.22.6)

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md