### PR TITLE
[IN-2544] fix the logic to updates cocoapods unless CI run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_03_11`
+* `fix the cocoapods update logic`
+
 ## `v2021_03_10`
 * `Upgrade DEN agent to v1.20.0`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_10
+export BITRISE_OSX_STACK_REV_ID=v2021_03_11
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/ruby-gems/tasks/main.yml
+++ b/roles/ruby-gems/tasks/main.yml
@@ -30,7 +30,9 @@
 
 - name: CocoaPods specs install with pod NOT FOR CI
   shell: bash -l -c "pod repo add master https://github.com/CocoaPods/Specs.git"
-  when: (cocoapods_specs_repo.before == None) and (not lookup('env', 'IS_CI'))
+  when: >
+    cocoapods_specs_repo.before == None and
+    not lookup('env', 'IS_CI')
 
 - name: Shallow checkout Cocoapds Specs repo FOR CI TEST
   git:
@@ -39,8 +41,10 @@
     clone: 'yes'
     update: 'yes'
     depth: 1
-  when: (cocoapods_specs_repo.before == None) and (lookup('env', 'IS_CI'))
+  when: >
+    cocoapods_specs_repo.before == None
+    and lookup('env', 'IS_CI')
 
 - name: "CocoaPods: pod repo update"
   shell: bash -l -c "pod repo update"
-  when: (cocoapods_specs_repo.before != cocoapods_specs_repo.after) and (cocoapods_specs_repo.before != None)
+  when: not lookup('env', 'IS_CI')


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md