### PR TITLE
[IN-2559] Install Go to /usr/local/go as the official documantation says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## UPCOMING
 
 
+## `v2021_03_16`
+* `Install Go under /usr/local/go`
+
 ## `v2021_03_12`
 * `Refactor and update den agent role`
 

--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -1,40 +1,31 @@
 ---
 - name: Check if Go is installed
-  shell: /usr/local/bin/go version | awk '{print $3}'
+  shell: /usr/local/go/bin/go version | awk '{print $3}'
   register: go_installation
   ignore_errors: true
   changed_when: false
 
 - name: Clean up old version if necesary
   file:
-    path: "{{ ansible_env.HOME }}/go"
+    path: /usr/local/go
     state: absent
+  become: true
   when: go_installation.stdout != go_version|string
 
 - name: Download Go
   get_url:
     url: https://golang.org/dl/{{ go_version }}.{{ ansible_system | lower }}-amd64.tar.gz
-    dest: /tmp/go{{ go_version }}.zip
+    dest: /tmp/{{ go_version }}.zip
   when: >
     go_installation.rc != 0 or
     go_installation.stdout != go_version|string
 
 - name: unarchive Go
   unarchive:
-    src: /tmp/go{{ go_version }}.zip
-    dest: "{{ ansible_env.HOME }}"
+    src: /tmp/{{ go_version }}.zip
+    dest: /usr/local/
     remote_src: true
-  when: >
-    go_installation.rc != 0 or
-    go_installation.stdout != go_version|string
-
-- name: install Go
-  file:
-    src: "{{ ansible_env.HOME }}/go/bin/go"
-    dest: /usr/local/bin/go
     owner: "{{ param_user }}"
-    mode: "0755"
-    state: link
   become: true
   when: >
     go_installation.rc != 0 or

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,7 +1,7 @@
 # Go tests
 def test_if_go_exists(host):
-    assert host.exists("/usr/local/bin/go")
-    assert host.run("go version").stdout.startswith('go version go1.15.7')
+    assert host.exists("/usr/local/go")
+    assert host.run("/usr/local/go/bin/go version").stdout.startswith('go version go1.15.7')
 
 def test_go_src_exists(host):
     bitrise = host.file("/home/linuxbrew/go/src")

--- a/roles/profiles/files/bashrc
+++ b/roles/profiles/files/bashrc
@@ -11,7 +11,7 @@ export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go
-export PATH="$PATH:/usr/local/opt/go/libexec/bin"
+export PATH="$PATH:/usr/local/go/bin"
 export GOPATH="$HOME/go"
 export PATH="$PATH:$GOPATH/bin"
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_12
+export BITRISE_OSX_STACK_REV_ID=v2021_03_16
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/profiles/files/zshrc
+++ b/roles/profiles/files/zshrc
@@ -10,7 +10,7 @@ export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go
-export PATH="$PATH:/usr/local/opt/go/libexec/bin"
+export PATH="$PATH:/usr/local/go/bin"
 export GOPATH="$HOME/go"
 export PATH="$PATH:$GOPATH/bin"
 


### PR DESCRIPTION
The package installs the Go distribution to /usr/local/go. The package should put the /usr/local/go/bin directory in your PATH environment variable. You may need to restart any open Terminal sessions for the change to take effect.

https://golang.org/doc/install