### PR TITLE
[IN-2559] Revert go install to brew, with a minor version fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## UPCOMING
 
 
+## `v2021_03_16_2`
+* `Revert go install to brew`
+
 ## `v2021_03_16`
 * `Install Go under /usr/local/go`
 

--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -5,8 +5,22 @@
     state: present
     update_homebrew: true
 
-- name: Link brew repo
-  shell: brew unlink go && brew link go@1.15
+- name: Test if there is a latest go installed
+  shell: brew list | grep -x "go"
+  args:
+    executable: /bin/bash
+  changed_when: false
+  ignore_errors: true
+  register: latest_is_installed
+
+- name: unlink latest go
+  shell: brew unlink go
+  args:
+    executable: /bin/bash
+  when: latest_is_installed.rc == 0
+
+- name: Link go 1.15
+  shell: brew link go@1.15
   args:
     executable: /bin/bash
 

--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -5,6 +5,11 @@
     state: present
     update_homebrew: true
 
+- name: Link brew repo
+  shell: brew unlink go && brew link go@1.15
+  args:
+    executable: /bin/bash
+
 - name: prepare GOPATH dirs
   file:
     path: "{{ ansible_env.HOME }}/go/{{ item.fold_path }}"

--- a/roles/go/tasks/main.yml
+++ b/roles/go/tasks/main.yml
@@ -1,35 +1,9 @@
 ---
-- name: Check if Go is installed
-  shell: /usr/local/go/bin/go version | awk '{print $3}'
-  register: go_installation
-  ignore_errors: true
-  changed_when: false
-
-- name: Clean up old version if necesary
-  file:
-    path: /usr/local/go
-    state: absent
-  become: true
-  when: go_installation.stdout != go_version|string
-
-- name: Download Go
-  get_url:
-    url: https://golang.org/dl/{{ go_version }}.{{ ansible_system | lower }}-amd64.tar.gz
-    dest: /tmp/{{ go_version }}.zip
-  when: >
-    go_installation.rc != 0 or
-    go_installation.stdout != go_version|string
-
-- name: unarchive Go
-  unarchive:
-    src: /tmp/{{ go_version }}.zip
-    dest: /usr/local/
-    remote_src: true
-    owner: "{{ param_user }}"
-  become: true
-  when: >
-    go_installation.rc != 0 or
-    go_installation.stdout != go_version|string
+- name: Install go
+  homebrew:
+    name: go@1.15
+    state: present
+    update_homebrew: true
 
 - name: prepare GOPATH dirs
   file:

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,20 +1,13 @@
 # Go tests
 def test_if_go_exists(host):
     assert host.exists("/usr/local/go")
-    assert host.run("/usr/local/go/bin/go version").stdout.startswith('go version go1.15.7')
+    assert host.run("go version").stdout.startswith('go version go1.15')
 
 def test_go_src_exists(host):
-    bitrise = host.file("/home/linuxbrew/go/src")
-    assert bitrise.is_directory
-    assert bitrise.exists
-    assert bitrise.user == "linuxbrew"
-
-def test_go_bin_exists(host):
-    bitrise = host.file("/home/linuxbrew/go/bin")
-    assert bitrise.is_directory
-    assert bitrise.user == "linuxbrew"
-
-def test_go_pkg_exists(host):
-    bitrise = host.file("/home/linuxbrew/go/pkg")
-    assert bitrise.is_directory
-    assert bitrise.user == "linuxbrew"
+    folder_base_path = "/home/linuxbrew/go/"
+    go_folders = ["src", "bin", "pkg"]
+    for folder in go_folders:
+        test_folder = host.file(folder_base_path + folder)
+        assert test_folder.is_directory
+        assert test_folder.exists
+        assert test_folder.user == "linuxbrew"

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,7 +1,7 @@
 # Go tests
 def test_if_go_exists(host):
-    assert host.exists("go")
-    assert host.run("go version").stdout.startswith('go version go1.15')
+    assert host.exists("/usr/local/opt/go/libexec/bin/go")
+    assert host.run("/usr/local/opt/go/libexec/bin/go version").stdout.startswith('go version go1.15')
 
 def test_go_src_exists(host):
     folder_base_path = "/home/linuxbrew/go/"

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,7 +1,7 @@
 # Go tests
 def test_if_go_exists(host):
-    assert host.exists("/usr/local/bin/go")
-    assert host.run("/usr/local/bin/go version").stdout.startswith('go version go1.15')
+    assert host.exists("/home/linuxbrew/.linuxbrew/bin/go")
+    assert host.run("/home/linuxbrew/.linuxbrew/bin/go version").stdout.startswith('go version go1.15')
 
 def test_go_src_exists(host):
     folder_base_path = "/home/linuxbrew/go/"

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,8 +1,4 @@
 # Go tests
-def test_if_go_exists(host):
-    assert host.exists("/usr/local/opt/go/libexec/bin/go")
-    assert host.run("/usr/local/opt/go/libexec/bin/go version").stdout.startswith('go version go1.15')
-
 def test_go_src_exists(host):
     folder_base_path = "/home/linuxbrew/go/"
     go_folders = ["src", "bin", "pkg"]

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,6 +1,6 @@
 # Go tests
 def test_if_go_exists(host):
-    assert host.exists("/usr/local/bin/go")
+    assert host.exists("go")
     assert host.run("go version").stdout.startswith('go version go1.15')
 
 def test_go_src_exists(host):

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,4 +1,8 @@
 # Go tests
+def test_if_go_exists(host):
+    assert host.exists("/usr/local/bin/go")
+    assert host.run("/usr/local/bin/go version").stdout.startswith('go version go1.15')
+
 def test_go_src_exists(host):
     folder_base_path = "/home/linuxbrew/go/"
     go_folders = ["src", "bin", "pkg"]

--- a/roles/go/tests/test_go.py
+++ b/roles/go/tests/test_go.py
@@ -1,6 +1,6 @@
 # Go tests
 def test_if_go_exists(host):
-    assert host.exists("/usr/local/go")
+    assert host.exists("/usr/local/bin/go")
     assert host.run("go version").stdout.startswith('go version go1.15')
 
 def test_go_src_exists(host):

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_16
+export BITRISE_OSX_STACK_REV_ID=v2021_03_16_2
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/profiles/files/zshrc
+++ b/roles/profiles/files/zshrc
@@ -10,7 +10,7 @@ export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # Go
-export PATH="$PATH:/usr/local/go/bin"
+export PATH="$PATH:/usr/local/opt/go/libexec/bin"
 export GOPATH="$HOME/go"
 export PATH="$PATH:$GOPATH/bin"
 


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md