### PR TITLE
[IN-2567] Make sure xamarin_profile gets sourced last if its there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## UPCOMING
 
 
+## `v2021_03_17`
+* `Change order of source so java does not override xamarin`
+
 ## `v2021_03_16`
 * `Install Go under /usr/local/go`
 

--- a/roles/profiles/files/bashrc
+++ b/roles/profiles/files/bashrc
@@ -34,17 +34,17 @@ if [ -s "$HOME/.profiles/tools_profile" ] ; then
   source "$HOME/.profiles/tools_profile"
 fi
 
-# Xamarin environments, if exists
-if [ -s "$HOME/.profiles/xamarin_profile" ] ; then
-  source "$HOME/.profiles/xamarin_profile"
-fi
-
 for PROFILE_SCRIPT in $( ls $HOME/profile.d/* ); do
   . $PROFILE_SCRIPT
 done
 
 if [ -f $HOME/profile.d/jenv.sh ]; then
   export JAVA_HOME="$(jenv prefix)"
+fi
+
+# Xamarin environments, if exists
+if [ -s "$HOME/.profiles/xamarin_profile" ] ; then
+  source "$HOME/.profiles/xamarin_profile"
 fi
 
 # keep a newline at the end of this file

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_16
+export BITRISE_OSX_STACK_REV_ID=v2021_03_17
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/profiles/files/zshrc
+++ b/roles/profiles/files/zshrc
@@ -33,17 +33,17 @@ if [ -s "$HOME/.profiles/tools_profile" ] ; then
   source "$HOME/.profiles/tools_profile"
 fi
 
-# Xamarin environments, if exists
-if [ -s "$HOME/.profiles/xamarin_profile" ] ; then
-  source "$HOME/.profiles/xamarin_profile"
-fi
-
 for PROFILE_SCRIPT in $( ls $HOME/profile.d/* ); do
   . $PROFILE_SCRIPT
 done
 
 if [ -f $HOME/profile.d/jenv.sh ]; then
   export JAVA_HOME="$(jenv prefix)"
+fi
+
+# Xamarin environments, if exists
+if [ -s "$HOME/.profiles/xamarin_profile" ] ; then
+  source "$HOME/.profiles/xamarin_profile"
 fi
 
 # keep a newline at the end of this file


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md