### PR TITLE
[IN-2552] Add ANDROID_SDK_ROOT in xamarin_profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_03_18_2`
+* `Set up SDK ROOT for xamarin`
+
 ## `v2021_03_18`
 * `Refactor and update Bitrise CLI`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_18
+export BITRISE_OSX_STACK_REV_ID=v2021_03_18_2
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/xamarin/files/xamarin_profile
+++ b/roles/xamarin/files/xamarin_profile
@@ -9,6 +9,7 @@ else
   # Xamarin Studio
   export ANDROID_NDK_HOME=$HOME/Library/Developer/Xamarin/android-ndk/android-ndk-r11c
 fi
+export ANDROID_SDK_ROOT=$ANDROID_HOME
 export COMPONENT_PATH="${BITRISE_XAMARIN_FOLDER_PATH}/xamarin-component"
 export NUNIT_3_PATH="${BITRISE_XAMARIN_FOLDER_PATH}/nunit/3.4.1/bin"
 export NUNIT_2_PATH="${BITRISE_XAMARIN_FOLDER_PATH}/nunit/2.6.4/bin"


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md