### PR TITLE
[IN-2473] (xcode) debug logs and robust xcode selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@
 
 ## `v2021_03_18_3`
 * `separate Spotlight and rerun in baseStack`
->>>>>>> master
 
 ## `v2021_03_18_2`
 * `Set up SDK ROOT for xamarin`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_03_18`
+* `(xcode) debug logs and robust xcode selection`
+
 ## `v2021_03_17`
 * `Change order of source so java does not override xamarin`
 

--- a/roles/brew-repos-fix/vars/main.yml
+++ b/roles/brew-repos-fix/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 homebrew_core:
-  sha: "ea2952690006bb831dc695bca422c1bc3ee88197"
+  sha: "8950942127872bd48cb22ab3f0a307df064b3b16"
 homebrew_cask:
-  sha: "8c9c53ada143379b4de2253d986981463c656fce"
+  sha: "c6777fb3c2fc229c307a00df49d525ce4be0595a"
 ...

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_17
+export BITRISE_OSX_STACK_REV_ID=v2021_03_18
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,11 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-<<<<<<< HEAD
 export BITRISE_OSX_STACK_REV_ID=v2021_03_29_1
-=======
-export BITRISE_OSX_STACK_REV_ID=v2021_03_25
->>>>>>> master
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/xcode/files/enable_accessibility.sh
+++ b/roles/xcode/files/enable_accessibility.sh
@@ -7,7 +7,9 @@ if test z$1 = z ; then
   exit 1
 fi
 
-if test "z$1" = "z10.15.6" || test "z$1" = "z10.15.7" ; then
+OS_MAJOR_VERSION="$(echo "$1" | cut -d. -f1)"
+
+if test "z$OS_MAJOR_VERSION" = z10; then
   #schema of the table on Catalina 10.15.6
   #
   #CREATE TABLE access (
@@ -27,7 +29,7 @@ if test "z$1" = "z10.15.6" || test "z$1" = "z10.15.7" ; then
   #  FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE);
   sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "INSERT INTO access VALUES('kTCCServiceAccessibility','com.apple.dt.Xcode',0,1,1,'','','','UNUSED','',0,'1606910422');"
 
-elif test "z$1" = "z11.2" || test "z$1" = "z11.2.3" ; then
+elif test "z$OS_MAJOR_VERSION" = z11; then
   # schema on Big Sur 11.2
   # CREATE TABLE access (
   # service        TEXT        NOT NULL,

--- a/roles/xcode/files/enable_accessibility.sh
+++ b/roles/xcode/files/enable_accessibility.sh
@@ -27,7 +27,7 @@ if test "z$1" = "z10.15.6" || test "z$1" = "z10.15.7" ; then
   #  FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE ON UPDATE CASCADE);
   sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "INSERT INTO access VALUES('kTCCServiceAccessibility','com.apple.dt.Xcode',0,1,1,'','','','UNUSED','',0,'1606910422');"
 
-elif test "z$1" = "z11.2" ; then
+elif test "z$1" = "z11.2" || test "z$1" = "z11.2.3" ; then
   # schema on Big Sur 11.2
   # CREATE TABLE access (
   # service        TEXT        NOT NULL,

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -34,19 +34,19 @@ name: Install xcode '{{ xcode_version }}', it could take a while. About an hour,
   when: xcode_select_selected.rc != 0
 
 - name: Check xcversion selected Xcode version
-  shell: bash -l -c "$HOME/.rbenv/shims/xcversion selected | grep Xcode | grep {{ xcode_version.split(' ')[0] }}"
+  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion selected | grep Xcode | grep {{ xcode_version.split(' ')[0] }}"
   register: xcversion_selected
   changed_when: false
   ignore_errors: true
 
 - name: Switch to Xcode stable with xcversion
   become: true
-  shell: bash -l -c "/Users/{{ param_user }}/.rbenv/shims/xcversion select {{ xcode_version.split(' ')[0] }}"
+  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion select {{ xcode_version.split(' ')[0] }}"
   when: xcversion_selected.rc !=0
 
 - name: Clean up Xcode install caches
   become: true
-  shell: bash -l -c "/Users/{{ param_user }}/.rbenv/shims/xcversion cleanup"
+  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion cleanup"
 
 - name: Enable accessibility to xcode
   become: true

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -39,6 +39,7 @@
 
 - name: Fix the Xcode.app symlink if not selected
   become: true
+  # Beta xcode versions require dots not spaces in the symlink
   shell: bash -l -c "/usr/bin/xcode-select --switch /Applications/Xcode-{{ xcode_version|replace(' ','.')}}.app"
 
 - name: Switch to Xcode stable with xcversion

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -5,17 +5,49 @@
     user_install: false
     executable: "$HOME/.rbenv/shims/gem"
 
-- name: Install xcode version based on xcode_version variable, it could take a while. About an hour, so be patient.
+- name: Install xcode '{{ xcode_version }}', it could take a while. About an hour, so be patient.
   shell: bash -l -c "$HOME/.rbenv/shims/xcversion install '{{ xcode_version }}'"
   environment:
     XCODE_INSTALL_USER: "{{ XCODE_INSTALL_USER }}"
     XCODE_INSTALL_PASSWORD: "{{ XCODE_INSTALL_PASSWORD }}"
     FASTLANE_SESSION: "{{ FASTLANE_SESSION | b64decode }}"
 
-- name: Switch to Xcode stable, the default Xcode for building
-  shell: bash -l -c "$HOME/.rbenv/shims/xcversion select '{{ xcode_version }}'"
+- name: Get the installed Xcode version
+  shell: bash -l -c "xcversion selected; xcode-select -p"
+  register: install_xcode_versions
+  changed_when: false
+  ignore_errors: true
+
+- name: Display the installed xcoder versions
+  debug:
+    msg: "{{ install_xcode_versions.stdout }}"
+
+- name: Check which Xcode is symlinked
+  shell: bash -l -c "xcode-select -p | grep {{ xcode_version.split(' ')[0] }}"
+  register: xcode_select_selected
+  changed_when: false
+  ignore_errors: true
+
+- name: Fix the Xcode.app symlink if not selected
   become: true
+  shell: bash -l -c "/usr/bin/xcode-select --switch /Applications/Xcode-{{ xcode_version|replace(' ','.')}}.app"
+  when: xcode_select_selected.rc != 0
+
+- name: Check xcversion selected Xcode version
+  shell: bash -l -c "$HOME/.rbenv/shims/xcversion selected | grep Xcode | grep {{ xcode_version.split(' ')[0] }}"
+  register: xcversion_selected
+  changed_when: false
+  ignore_errors: true
+
+- name: Switch to Xcode stable with xcversion
+  become: true
+  shell: bash -l -c "/Users/{{ param_user }}/.rbenv/shims/xcversion select {{ xcode_version.split(' ')[0] }}"
+  when: xcversion_selected.rc !=0
+
+- name: Clean up Xcode install caches
+  become: true
+  shell: bash -l -c "/Users/{{ param_user }}/.rbenv/shims/xcversion cleanup"
 
 - name: Enable accessibility to xcode
-  script: enable_accessibility.sh '{{ ansible_distribution_version }}'
   become: true
+  script: enable_accessibility.sh '{{ ansible_distribution_version }}'

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -18,7 +18,7 @@
   changed_when: false
   ignore_errors: true
 
-- name: Display the installed xcoder versions
+- name: Display the installed xcode versions
   debug:
     msg: "{{ install_xcode_versions.stdout }}"
 

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -5,7 +5,7 @@
     user_install: false
     executable: "{{ ansible_env.HOME }}/.rbenv/shims/gem"
 
-- name: Install xcode version based on xcode_version variable, it could take a while. About an hour, so be patient.
+name: Install xcode '{{ xcode_version }}', it could take a while. About an hour, so be patient.
   shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion install '{{ xcode_version }}'"
   environment:
     XCODE_INSTALL_USER: "{{ XCODE_INSTALL_USER }}"

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -40,7 +40,7 @@
 - name: Fix the Xcode.app symlink if not selected
   become: true
   # Beta xcode versions require dots not spaces in the symlink
-  shell: bash -l -c "/usr/bin/xcode-select --switch /Applications/Xcode-{{ xcode_version|replace(' ','.')}}.app"
+  shell: bash -l -c "/usr/bin/xcode-select --switch /Applications/Xcode-{{ xcode_version|replace(' ','.') }}.app"
 
 - name: Switch to Xcode stable with xcversion
   become: true

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Extract Xcode major version
+  set_fact:
+    xcode_major_version: "{{ xcode_version.split(' ')[0] }}"
+
 - name: Install xcode-install
   gem:
     name: xcode-install
@@ -23,7 +27,7 @@ name: Install xcode '{{ xcode_version }}', it could take a while. About an hour,
     msg: "{{ install_xcode_versions.stdout }}"
 
 - name: Check which Xcode is symlinked
-  shell: bash -l -c "xcode-select -p | grep {{ xcode_version.split(' ')[0] }}"
+  shell: bash -l -c "xcode-select -p | grep {{ xcode_major_version }}"
   register: xcode_select_selected
   changed_when: false
   ignore_errors: true
@@ -34,14 +38,14 @@ name: Install xcode '{{ xcode_version }}', it could take a while. About an hour,
   when: xcode_select_selected.rc != 0
 
 - name: Check xcversion selected Xcode version
-  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion selected | grep Xcode | grep {{ xcode_version.split(' ')[0] }}"
+  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion selected | grep Xcode | grep {{ xcode_major_version }}"
   register: xcversion_selected
   changed_when: false
   ignore_errors: true
 
 - name: Switch to Xcode stable with xcversion
   become: true
-  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion select {{ xcode_version.split(' ')[0] }}"
+  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion select {{ xcode_major_version }}"
   when: xcversion_selected.rc !=0
 
 - name: Clean up Xcode install caches

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
-- name: Extract Xcode major version
+# When installing betas, they install from a string e.g `12.5 beta 3`
+- name: Extract Xcode version
   set_fact:
-    xcode_major_version: "{{ xcode_version.split(' ')[0] }}"
+    xcode_numeric_version: "{{ xcode_version.split(' ')[0] }}"
 
 - name: Install xcode-install
   gem:
@@ -16,43 +17,37 @@ name: Install xcode '{{ xcode_version }}', it could take a while. About an hour,
     XCODE_INSTALL_PASSWORD: "{{ XCODE_INSTALL_PASSWORD }}"
     FASTLANE_SESSION: "{{ FASTLANE_SESSION | b64decode }}"
 
-- name: Display the installed Xcode version
+- name: Get and display the current Xcode version
   block:
+    - name: get the xcode versions from xcversion
+      shell: bash -l -c "xcversion selected"
+      register: xcversion_selected
+      changed_when: false
+      ignore_errors: true
+
     - name: get the xcode versions from xcversion and xcode-select
-      shell: bash -l -c "xcversion selected; xcode-select -p"
-      register: install_xcode_versions
+      shell: bash -l -c "xcode-select -p"
+      register: xcode_select_path
       changed_when: false
       ignore_errors: true
 
    - name: Display the installed xcode versions
      debug:
-       msg: "{{ install_xcode_versions.stdout }}"
-
-- name: Check which Xcode is symlinked
-  shell: bash -l -c "xcode-select -p | grep {{ xcode_major_version }}"
-  register: xcode_select_selected
-  changed_when: false
-  ignore_errors: true
+       msg: "xcversion: {{ xcversion_selected.stdout }}" "xcode-select: {{ xcode_select_path.stdout }}"
 
 - name: Fix the Xcode.app symlink if not selected
   become: true
   shell: bash -l -c "/usr/bin/xcode-select --switch /Applications/Xcode-{{ xcode_version|replace(' ','.')}}.app"
-  when: xcode_select_selected.rc != 0
-
-- name: Check xcversion selected Xcode version
-  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion selected | grep Xcode | grep {{ xcode_major_version }}"
-  register: xcversion_selected
-  changed_when: false
-  ignore_errors: true
+  when: xcode_select_path.stdout is search("{{xcode_numeric_version}}")
 
 - name: Switch to Xcode stable with xcversion
   become: true
-  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion select {{ xcode_major_version }}"
-  when: xcversion_selected.rc !=0
+  shell: bash -l -c "xcversion select {{ xcode_numeric_version }}"
+  when: xcversion_selected.stdout is search("{{xcode_numeric_version}}"
 
 - name: Clean up Xcode install caches
   become: true
-  shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion cleanup"
+  shell: bash -l -c "xcversion cleanup"
 
 - name: Enable accessibility to xcode
   become: true

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -10,7 +10,7 @@
     user_install: false
     executable: "{{ ansible_env.HOME }}/.rbenv/shims/gem"
 
-name: Install xcode '{{ xcode_version }}', it could take a while. About an hour, so be patient.
+- name: Install xcode "{{ xcode_version }}", it could take a while. About an hour, so be patient.
   shell: bash -l -c "{{ ansible_env.HOME }}/.rbenv/shims/xcversion install '{{ xcode_version }}'"
   environment:
     XCODE_INSTALL_USER: "{{ XCODE_INSTALL_USER }}"
@@ -31,23 +31,25 @@ name: Install xcode '{{ xcode_version }}', it could take a while. About an hour,
       changed_when: false
       ignore_errors: true
 
-   - name: Display the installed xcode versions
-     debug:
-       msg: "xcversion: {{ xcversion_selected.stdout }}" "xcode-select: {{ xcode_select_path.stdout }}"
+    - name: Display the installed xcode versions
+      debug:
+        msg:
+        - "xcversion: {{ xcversion_selected.stdout }}"
+        - "xcode-select: {{ xcode_select_path.stdout }}"
 
 - name: Fix the Xcode.app symlink if not selected
   become: true
   shell: bash -l -c "/usr/bin/xcode-select --switch /Applications/Xcode-{{ xcode_version|replace(' ','.')}}.app"
-  when: xcode_select_path.stdout is search("{{xcode_numeric_version}}")
 
 - name: Switch to Xcode stable with xcversion
   become: true
-  shell: bash -l -c "xcversion select {{ xcode_numeric_version }}"
-  when: xcversion_selected.stdout is search("{{xcode_numeric_version}}"
+  # Full path required here because of the 'become:true'
+  shell: bash -l -c "/Users/{{ param_user }}/.rbenv/shims/xcversion select {{ xcode_numeric_version }}"
 
 - name: Clean up Xcode install caches
+  # Full path required here because of the 'become:true'
   become: true
-  shell: bash -l -c "xcversion cleanup"
+  shell: bash -l -c "/Users/{{ param_user }}/.rbenv/shims/xcversion cleanup"
 
 - name: Enable accessibility to xcode
   become: true

--- a/roles/xcode/tasks/main.yml
+++ b/roles/xcode/tasks/main.yml
@@ -16,15 +16,17 @@ name: Install xcode '{{ xcode_version }}', it could take a while. About an hour,
     XCODE_INSTALL_PASSWORD: "{{ XCODE_INSTALL_PASSWORD }}"
     FASTLANE_SESSION: "{{ FASTLANE_SESSION | b64decode }}"
 
-- name: Get the installed Xcode version
-  shell: bash -l -c "xcversion selected; xcode-select -p"
-  register: install_xcode_versions
-  changed_when: false
-  ignore_errors: true
+- name: Display the installed Xcode version
+  block:
+    - name: get the xcode versions from xcversion and xcode-select
+      shell: bash -l -c "xcversion selected; xcode-select -p"
+      register: install_xcode_versions
+      changed_when: false
+      ignore_errors: true
 
-- name: Display the installed xcode versions
-  debug:
-    msg: "{{ install_xcode_versions.stdout }}"
+   - name: Display the installed xcode versions
+     debug:
+       msg: "{{ install_xcode_versions.stdout }}"
 
 - name: Check which Xcode is symlinked
   shell: bash -l -c "xcode-select -p | grep {{ xcode_major_version }}"


### PR DESCRIPTION
- [IN-2473] (xcode) debug logs and robust xcode selection
- metadatas

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md

I have added some debug loggin so we can see in the Ansible output what version and build ID Xcode is installed
I took the opportunity to make better use of xcversion and xcode-select to ensure the environment is setup
correctly for developers


[IN-2473]: https://bitrise.atlassian.net/browse/IN-2473