### PR TITLE
[IN-2601] Run brew upgrade during weekly cache update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_03_31`
+* `upgrade brew cache during weekly update`
+
 ## `v2021_03_30_2`
 * `jq bin fix for den`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_30_2
+export BITRISE_OSX_STACK_REV_ID=v2021_03_31
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/weekly-update-shared/tasks/main.yml
+++ b/roles/weekly-update-shared/tasks/main.yml
@@ -109,3 +109,9 @@
 - name: Brew cleanup weekly
   include_role:
     name: brew-cleanup-weekly
+
+- name: Brew upgrade cache
+  shell: bash -l -c "brew upgrade --force -q"
+  # even if the upgrades are installed,
+  # if we get a warning, the exit code is not 0
+  ignore_errors: true


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md