### PR TITLE
[IN-2598] Init simulators as vagrant, not root

### DIFF
--- a/06.baseStack-playbook.yml
+++ b/06.baseStack-playbook.yml
@@ -29,5 +29,6 @@
     - role: misc-setup
     - role: node
     - role: ruby-gems
+    - role: simulators
     - role: weekly-update-shared
     - role: used-tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_04_07`
+* `initialise simulators as vagrant, not root`
+
 ## `v2021_03_31`
 * `upgrade brew cache during weekly update`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_03_31
+export BITRISE_OSX_STACK_REV_ID=v2021_04_07
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/simulators/tasks/main.yml
+++ b/roles/simulators/tasks/main.yml
@@ -16,7 +16,6 @@
 # and `xcrun simctl list` will take quite some time (~60 seconds).
 - name: xcrun simctl list
   shell: bash -l -c "xcrun simctl list"
-  become: true
 
 - name: Cleanup cached downloads
   shell: bash -l -c "xcversion cleanup"


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md