### PR TITLE
Disable weak SSH ciphers

### DIFF
--- a/roles/ssh-setup/templates/etc/ssh/sshd_config.j2
+++ b/roles/ssh-setup/templates/etc/ssh/sshd_config.j2
@@ -20,6 +20,6 @@ ChallengeResponseAuthentication     {{ ssh.challenge_response_authentication }}
 UseDNS                              {{ ssh.use_dns }}
 
 # Disable weak ciphers
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
-Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+MACs                                hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
+Ciphers                             aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+KexAlgorithms                       ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256

--- a/roles/ssh-setup/templates/etc/ssh/sshd_config.j2
+++ b/roles/ssh-setup/templates/etc/ssh/sshd_config.j2
@@ -18,3 +18,8 @@ LogLevel                            {{ ssh.log_level }}
 UsePAM                              {{ ssh.use_pam }}
 ChallengeResponseAuthentication     {{ ssh.challenge_response_authentication }}
 UseDNS                              {{ ssh.use_dns }}
+
+# Disable weak ciphers
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256

--- a/roles/ssh-setup/templates/etc/ssh/sshd_config.j2
+++ b/roles/ssh-setup/templates/etc/ssh/sshd_config.j2
@@ -19,7 +19,7 @@ UsePAM                              {{ ssh.use_pam }}
 ChallengeResponseAuthentication     {{ ssh.challenge_response_authentication }}
 UseDNS                              {{ ssh.use_dns }}
 
-# Disable weak ciphers
+# disable weak ciphers
 MACs                                hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 Ciphers                             aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 KexAlgorithms                       ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256


### PR DESCRIPTION
By default, SSH enables some weak cipher suites. Let's disable them (by enabling only the "strong" algos) to comly with [Bitrise Encryption Policy](https://bitrise.atlassian.net/wiki/spaces/SEC/pages/1391722649/Bitrise+Encryption+Policy).

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md