### PR TITLE
[IN-2638]: revert ios 14.5 from 12.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2021_04_21_1`
+* `Revert installing iOS 14.5 from 12.5.x`
+
 ## `v2021_04_21`
 * `Update xcode_version to 12.5 RC1`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_04_21
+export BITRISE_OSX_STACK_REV_ID=v2021_04_21_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/simulators/vars/12.5.yml
+++ b/roles/simulators/vars/12.5.yml
@@ -5,7 +5,6 @@ simulators:
   - 'watchOS 6.2.1'
   - 'tvOS 14.4'
   - 'tvOS 13.4'
-  - 'iOS 14.5'
   - 'iOS 14.4'
   - 'iOS 14.3'
   - 'iOS 14.2'


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md