### PR TITLE
[IN-2762] fix xcbeautify version call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## UPCOMING
 
+## `v2012_05_29`
+* `Fix xcbeautify version check`
+
 ## `v2012_05_28_3`
 * `Change rol order to set up brew before using it`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2012_05_28_3
+export BITRISE_OSX_STACK_REV_ID=v2012_05_29
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/roles/weekly-update-shared/tasks/tools-from-artifacts.yml
+++ b/roles/weekly-update-shared/tasks/tools-from-artifacts.yml
@@ -25,7 +25,7 @@
 
 # XCBeautify
 - name: Check if XCBeautify is present
-  shell: /usr/local/bin/xcbeautify version | awk '{print $2}'
+  shell: /usr/local/bin/xcbeautify --version | awk '{print $2}'
   register: xcbeautify_version
   ignore_errors: true
   no_log: true


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [x] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [x] I updated the corresponding tests if there were any.
- [x] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md