### PR TITLE
[IN-2823] chore(bitrise-den): update agent to 1.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## `v2021_06_30`
+* `update agent to 1.30.1`
+
 ## `v2021_06_28`
 * `add 13.0 option to simulators`
 

--- a/roles/bitrise-den/defaults/main.yml
+++ b/roles/bitrise-den/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-bitrise_den_version: "v1.30.0"
+bitrise_den_version: "v1.30.1"
 dist_path:
   MacOSX: '/usr/local/bin/jq'
   Ubuntu: 'jq'

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_06_28
+export BITRISE_OSX_STACK_REV_ID=v2021_06_30
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md