### PR TITLE
Update Android SDK command line tools to 7583922.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## `v2021_08_09_1`
+* `Upgrade Android SDK command line tools to version 7583922 for Java 11 compatibility.`
+
 ## `v2021_07_28_1`
 * `Correct the stack layers order`
 

--- a/roles/android/defaults/main.yml
+++ b/roles/android/defaults/main.yml
@@ -4,7 +4,7 @@ android_ndk_home: /opt/android-ndk
 android_ndk_version: r21e
 android_origin: dl.google.com/android/repository
 android_ndk_source: https://{{ android_origin }}/android-ndk-{{ android_ndk_version }}-darwin-x86_64.zip
-android_cmdline_tools_version: 7302050
+android_cmdline_tools_version: 7583922
 android_cmdline_tools_source: https://{{ android_origin }}/commandlinetools-mac-{{ android_cmdline_tools_version }}_latest.zip  # yamllint disable-line rule:line-length
 sdkmanagerpackages:
   - "emulator"

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2021_07_28_1
+export BITRISE_OSX_STACK_REV_ID=v2021_08_09_1
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"


### PR DESCRIPTION
Upgrading to this version ensures that command line tools are compatible with Java 11. The recently released Android Gradle Plugin 7.0 also requires Java 11 to run.

### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [ ] I added a version report line to [`system_report.sh`](/system_report.sh) for the new tool(s) I added
- [ ] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [ ] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md