### PR TITLE
[IN-3566] Added groovy version info to the preinstalled tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## `v2022_04_20`
+* `Groovy added to sysreport pre-installed section`
+
 ## `v2022_04_06`
 * `Pre-install groovy`
 

--- a/roles/profiles/files/bitrise_profile
+++ b/roles/profiles/files/bitrise_profile
@@ -1,7 +1,7 @@
 # for debug
 export DOT_BITRISE_PROFILE_LOADED=1
 
-export BITRISE_OSX_STACK_REV_ID=v2022_04_08
+export BITRISE_OSX_STACK_REV_ID=v2022_04_20
 
 # Bitrise Environment Variables
 export BITRISE_SOURCE_DIR="${HOME}/git"

--- a/system_report.sh
+++ b/system_report.sh
@@ -31,6 +31,7 @@ ver_line="$(node --version)" ;                    echo "* Node.js: $ver_line"
 ver_line="$(npm --version)" ;                     echo "* NPM: $ver_line"
 ver_line="$(yarn --version)" ;                    echo "* Yarn: $ver_line"
 ver_line="$(java -version 2>&1 >/dev/null)" ;     echo "* Java: $ver_line"
+ver_line="$(groovy -version)" ;                   echo "* Groovy: $ver_line"
 # This is needed because Flutter version displays a message on the first try
 # that new updates are available, and only displays the actual version afterwards
 # When we run it again it displays the current version only


### PR DESCRIPTION
### New Pull Request Checklist

*Please mark the points which you did / accept.*

- [ ] The tool I added is stable, and __does not require frequent updates__. _Preinstalled tools on the LTS stacks
  are not updated, so if the tool requires frequent updates you should handle the installation on-demand (see: [Install Any Additional Tool - DevCenter](https://bitrise-io.github.io/devcenter/tips-and-tricks/install-additional-tools/) for more information)_
- [ ] I updated the corresponding tests if there were any.
- [x] I added a version report line to [`system_report.sh`](system_report.sh) for the new tool(s) I added
- [x] I have added an entry to the CHANGELOG.md with a revisionID (the current date and the number of the change e.g.: 2019_10_11_1) and a brief description of the actual change
- [x] I have updated the revisionID in [bitrise_profile](roles/profiles/files/bitrise_profile) **BITRISE_OSX_STACK_REV_ID** with the one I just created in the CHANGELOG.md
